### PR TITLE
Removed empty line before table when serializing

### DIFF
--- a/Source/Nett/TomlStreamWriter.cs
+++ b/Source/Nett/TomlStreamWriter.cs
@@ -116,7 +116,6 @@ namespace Nett
             this.WritePrependComments(table);
             if (this.writeTableKey && !string.IsNullOrEmpty(this.CurrentRowKey))
             {
-                sw.WriteLine();
                 this.sw.WriteLine("[{0}]", this.GetKey(this.CurrentRowKey));
                 this.WriteApppendComments(table);
             }


### PR DESCRIPTION
Removed unnecessary empty line which was written before table which was leading to first-line space and confusing comments.

How it was (notice first line of file contains empty space):
```toml


[my_table]
abc = 123

# comment to "next_table" via [TomlComment] attr

[next_table]
cba = 321
```

After fix:
```toml
[my_table]
abc = 123

# comment to "next_table" via [TomlComment] attr
[next_table]
cba = 321
```