### PR TITLE
Faster TOML serialization by getting rid of String.Format methods

### DIFF
--- a/Source/Nett/TomlStreamWriter.cs
+++ b/Source/Nett/TomlStreamWriter.cs
@@ -107,7 +107,7 @@ namespace Nett
                 this.WriteTableRow(rows[rows.Length - 1]);
             }
 
-            this.sw.Write("}");
+            this.sw.Write('}');
             this.WriteAppendComments(table);
             this.writeInlineTableInvocationsRunning--;
         }
@@ -122,11 +122,11 @@ namespace Nett
             this.WritePrependComments(table);
             if (this.writeTableKey && !string.IsNullOrEmpty(this.CurrentRowKey))
             {
-                sw.WriteLine();
+                this.sw.WriteLine();
                 this.sw.Write('[');
                 this.sw.Write(this.GetKey(this.CurrentRowKey));
                 this.sw.Write(']');
-                this.sw.Write(sw.NewLine);
+                this.sw.Write(this.sw.NewLine);
                 this.WriteAppendComments(table);
             }
 
@@ -168,7 +168,7 @@ namespace Nett
                     array.Items[array.Items.Length - 1].Visit(this);
                 }
 
-                this.sw.Write("]");
+                this.sw.Write(']');
                 this.WriteAppendComments(array);
             }
         }
@@ -182,7 +182,10 @@ namespace Nett
                 foreach (var t in tableArray.Items)
                 {
                     Assert(this.CurrentRowKey != null);
-                    this.sw.WriteLine($"[[{this.CurrentRowKey}]]");
+                    this.sw.Write("[[");
+                    this.sw.Write(this.CurrentRowKey);
+                    this.sw.Write("]]");
+                    this.sw.Write(this.sw.NewLine);
                     this.WriteAppendComments(tableArray);
                     t.Visit(this);
                     this.sw.WriteLine();


### PR DESCRIPTION
I have made quick perftest on this which shown about 50% speed increase when replacing String.Format powered writes like this
```c#
streamWriter.WriteLine(String.Format("abc {0}", 123))
```
to
```c#
streamWriter.Write("abc ");
streamWriter.Write(123);
streamWriter.Write(streamWriter.NewLine);
```
Source code for test: https://gist.github.com/miere43/7bbb3a59e13737dfc2593b21f8009d94

Passes all debug/release tests.

(also I fixed typo in one method :dog:)

This pull request doesn't include #10 issue fix.