### PR TITLE
Don't output JSON twice

### DIFF
--- a/Test/Nett.TestDecoder/Program.cs
+++ b/Test/Nett.TestDecoder/Program.cs
@@ -22,8 +22,6 @@ namespace Nett.TestDecoder
                 var json = conv.Convert(t);
                 writer.Write(json);
 
-                Console.WriteLine(json);
-
                 return 0;
             }
             catch (Exception exc)


### PR DESCRIPTION
I noticed that the test decoder outputs the json representation of the Toml document it's given twice. This patch removes the second emission. I've tested that with and without this patch makes no difference to running with toml-test.