### PR TITLE
Inline Table Bug 2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.cs]
+indent_style = space
+indent_size = 4
+insert_final_newline = true

--- a/Source/Nett/Parser/Productions/InlineTableProduction.cs
+++ b/Source/Nett/Parser/Productions/InlineTableProduction.cs
@@ -8,7 +8,7 @@
 
             tokens.ExpectAndConsume(TokenType.LCurly);
 
-            if (!tokens.TryExpect(TokenType.RBrac))
+            if (!tokens.TryExpect(TokenType.RCurly))
             {
                 var kvp = KeyValuePairProduction.Apply(root, tokens);
                 inlineTable.AddRow(kvp.Item1, kvp.Item2);

--- a/Test/Nett.Tests/VerifyIssuesTests.cs
+++ b/Test/Nett.Tests/VerifyIssuesTests.cs
@@ -282,6 +282,20 @@ B = {  }
 ");
         }
 
+        [Fact]
+        public void VerifyIssue53_EmptyInlineTableFailsToBeParsed_IsFixed()
+        {
+            // Arrange
+            const string Tml = @"
+[Root]
+A = {  }
+";
+            Action action = () => Toml.ReadString(Tml);
+
+            // Assert
+            action.ShouldNotThrow();
+        }
+
         public class TestTable
         {
             public string label { get; set; }


### PR DESCRIPTION
## Inline table bug

Nett correctly generates an empty table when serializing (see #51).
But this in example it throws an exception when reading it again:
```csharp
public static void Main()
{
	Toml.ReadString(@"
[Root]
A = {  }
");
}
```

```csharp
System.Exception
  Message=Line 3, Column 8: Failed to parse key because unexpected token '}' was found.
  Source=Nett
  StackTrace:
   at Nett.Parser.Productions.KeyProduction.ApplyInternal(TokenBuffer tokens, Boolean required) in C:\Dev\Nett\Source\Nett\Parser\Productions\KeyProduction.cs:line 37
   at Nett.Parser.Productions.KeyValuePairProduction.Apply(ITomlRoot root, TokenBuffer tokens) in C:\Dev\Nett\Source\Nett\Parser\Productions\KeyValuePairProduction.cs:line 11
   at Nett.Parser.Productions.InlineTableProduction.Apply(ITomlRoot root, TokenBuffer tokens) in C:\Dev\Nett\Source\Nett\Parser\Productions\InlineTableProduction.cs:line 11
   at Nett.Parser.Productions.InlineTableProduction.TryApply(ITomlRoot root, TokenBuffer tokens) in C:\Dev\Nett\Source\Nett\Parser\Productions\InlineTableProduction.cs:line 29
   at Nett.Parser.Productions.KeyValuePairProduction.Apply(ITomlRoot root, TokenBuffer tokens) in C:\Dev\Nett\Source\Nett\Parser\Productions\KeyValuePairProduction.cs:line 26
   at Nett.Parser.Productions.ExpressionsProduction.TryApply(TomlTable current, RootTable root, TokenBuffer tokens) in C:\Dev\Nett\Source\Nett\Parser\Productions\ExpressionProduction.cs:line 67
   at Nett.Parser.Parser.Toml() in C:\Dev\Nett\Source\Nett\Parser\Parser.cs:line 68
   at Nett.Toml.ReadFile(String filePath, TomlSettings settings) in C:\Dev\Nett\Source\Nett\Toml.cs:line 116
```

## Editorconfig
I've also added an `.editorconfig` file, as I use tabs and this makes it way easier to contribute.
`.editorconfig` is an already widespread configuration format supported by many editors.
I tried to deduct the basic settings from the existing code.
If you're unsatisfied with this config, want it in an extra pr or don't like it at all let me know.

## Unexpected behavior on some tests
12 Tests are failing on my machine, mostly because of inconsistent line endings.
For example `Nett.Coma.Tests.Functional.Write_WithInlineTableProperty_WritesThatTableAsInlineTable()` fails with
```
Message: Expected string to be 
"UserItems = { X = true, Y = false }\n" with a length of 36, but 
"UserItems = { X = true, Y = false }\r\n" has a length of 37.
```
When changing
https://github.com/paiden/Nett/blob/e42d4b19c4bfebcc80195ba35d02843c3f9d4eab/Test/Nett.Coma.Tests/Functional/InlineTableTest.cs#L44
to `f.ShouldBeSemanticallyEquivalentTo(expected);` it works.

Would you mind another pull request where I change those affected tests?