### PR TITLE
Fixes #57

### DIFF
--- a/Source/Nett/Parser/Lexer.cs
+++ b/Source/Nett/Parser/Lexer.cs
@@ -301,6 +301,11 @@ namespace Nett.Parser
                 this.SkipChar();
                 this.EnterState(fc => this.LexMultilineString(fc, t, escape), label: this.SkipChar);
             }
+            else if (c == escape)
+            {
+                this.EnterState(fc => this.LexSingleLineString(fc, t, escape));
+                this.Consume();
+            }
             else if (c == t) { this.Accept(GetStringType(t), this.SkipChar); }
             else if (c == '\r' || c == '\n') { this.Fail(ErrNewlineInString); }
             else if (c == LexInput.EofChar) { this.Fail(ErrStringNotClosed); }

--- a/Test/Nett.Coma.Tests/Functional/InlineTableTest.cs
+++ b/Test/Nett.Coma.Tests/Functional/InlineTableTest.cs
@@ -41,7 +41,7 @@ namespace Nett.Coma.Tests.Functional
 
                 // Assert
                 var f = File.ReadAllText(file);
-                f.Should().Be(expected);
+                f.ShouldBeNormalizedEqualTo(expected);
             }
         }
 

--- a/Test/Nett.Tests.Util/AssertionExtensions.cs
+++ b/Test/Nett.Tests.Util/AssertionExtensions.cs
@@ -20,6 +20,19 @@ namespace Nett.Tests.Util
             sx.StripWhitespace().Should().Be(sy.StripWhitespace());
         }
 
+        /// <summary>
+        /// Checks that the readable contents of two string is the same but changes "\r\n" and "\r" line endings to "\n" before.
+        /// </summary>
+        /// <remarks>
+        /// The toml specification is rather free with line endings and says
+        /// "TOML parsers should feel free to normalize newline to whatever makes sense for their platform."
+        /// So in most cases we should just check that a line break exists and not which kind it is.
+        /// </remarks>
+        public static void ShouldBeNormalizedEqualTo(this string sx, string sy)
+        {
+            sx.NormalizeLineEndings().Should().Be(sy.NormalizeLineEndings());
+        }
+
         public static void SouldBeEqualByJsonCompare(this object x, object y)
         {
             var xj = JsonConvert.SerializeObject(x);

--- a/Test/Nett.Tests.Util/StringExtensions.cs
+++ b/Test/Nett.Tests.Util/StringExtensions.cs
@@ -20,6 +20,9 @@ namespace Nett.Tests.Util
         public static string StripWhitespace(this string s) =>
             s.Replace(" ", "").Replace("\t", "").Replace("\n", "").Replace("\r", "");
 
+        public static string NormalizeLineEndings(this string s) =>
+           s.Replace("\r\n", "\n").Replace("\r", "\n");
+
         public static string TestRunUniqueName(this string s) => $"../../../../data/{s}_{Guid.NewGuid().ToString("N").Substring(0, 8)}";
 
         public static string TestRunUniqueName(this string s, string fileExtension) => s.TestRunUniqueName() + fileExtension;

--- a/Test/Nett.Tests/Functional/InlineTableTests.Write.cs
+++ b/Test/Nett.Tests/Functional/InlineTableTests.Write.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using FluentAssertions;
+using Nett.Tests.Util;
 using Xunit;
 
 namespace Nett.Tests.Functional
@@ -15,7 +15,7 @@ namespace Nett.Tests.Functional
 
             var s = Toml.WriteString(ItemDict.TwoItems, config);
 
-            s.Should().Be(ItemDict.TwoItemsInlineSerialzed);
+            s.ShouldBeNormalizedEqualTo(ItemDict.TwoItemsInlineSerialzed);
         }
 
         [Fact]
@@ -27,7 +27,7 @@ namespace Nett.Tests.Functional
 
             var s = Toml.WriteString(ItemDict.TwoItems, config);
 
-            s.Should().Be(ItemDict.TwoItemsDictInlineSerialized);
+            s.ShouldBeNormalizedEqualTo(ItemDict.TwoItemsDictInlineSerialized);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Nett.Tests.Functional
 
             var s = Toml.WriteString(InlineArray.Empty, config);
 
-            s.Should().Be(InlineArray.ExpectedEmpty);
+            s.ShouldBeNormalizedEqualTo(InlineArray.ExpectedEmpty);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace Nett.Tests.Functional
 
             var s = Toml.WriteString(InlineArray.TwoItems, config);
 
-            s.Should().Be(InlineArray.ExpectedTwoItems);
+            s.ShouldBeNormalizedEqualTo(InlineArray.ExpectedTwoItems);
         }
 
 
@@ -61,7 +61,7 @@ namespace Nett.Tests.Functional
         {
             var s = Toml.WriteString(InlineArrayAttributeOnItem.TwoItems);
 
-            s.Should().Be(InlineArrayAttributeOnItem.TowItemsSerialized);
+            s.ShouldBeNormalizedEqualTo(InlineArrayAttributeOnItem.TowItemsSerialized);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace Nett.Tests.Functional
         {
             var s = Toml.WriteString(new ConfigWithStringBoolDict());
 
-            s.Should().Be(ConfigWithStringBoolDict.Serialized);
+            s.ShouldBeNormalizedEqualTo(ConfigWithStringBoolDict.Serialized);
         }
     }
 }

--- a/Test/Nett.Tests/ReadValidTomlUntypedTests.cs
+++ b/Test/Nett.Tests/ReadValidTomlUntypedTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using FluentAssertions;
+using Nett.Tests.Util;
 using Nett.Tests.Util.TestData;
 using Xunit;
 
@@ -483,7 +484,7 @@ namespace Nett.Tests
             Assert.Equal(3, read.Rows.Count());
             Assert.Equal("This string has a ' quote character.", read.Get<string>("oneline"));
             Assert.Equal("This string has a ' quote character.", read.Get<string>("firstnl"));
-            Assert.Equal("This string\r\n has a ' quote character\r\n and more than\r\n one newline\r\n in it.", read.Get<string>("multiline"));
+            Assert.Equal("This string\r\n has a ' quote character\r\n and more than\r\n one newline\r\n in it.".NormalizeLineEndings(), read.Get<string>("multiline").NormalizeLineEndings());
         }
 
         [Fact]

--- a/Test/Nett.Tests/VerifyIssuesTests.cs
+++ b/Test/Nett.Tests/VerifyIssuesTests.cs
@@ -225,7 +225,7 @@ SomeValue = 5";
             tbl.Add("root5", 5);    // Added at root level but spuriously written into [Level2.Level3]
 
             var result = Toml.WriteString(tbl);
-            result.Trim().Should().Be(@"
+            result.Trim().ShouldBeNormalizedEqualTo(@"
 root1 = 1
 root2 = 2
 root3 = 3
@@ -330,7 +330,7 @@ A = {  }
             var table = Toml.ReadString(Tml);
 
             // Assert
-            ((TomlValue<string>)table["a"]).Value.Should().Be("\"");
+            table.Get<string>("a").Should().Be("\"");
         }
 
         public class TestTable

--- a/Test/Nett.Tests/VerifyIssuesTests.cs
+++ b/Test/Nett.Tests/VerifyIssuesTests.cs
@@ -320,6 +320,19 @@ A = {  }
             obj.ShouldBeEquivalentTo(new MultiDimArray());
         }
 
+        [Fact]
+        public void VerifyIssue57_EscapedQuoteAtStartOfStringFailsToBeParsed_IsFixed()
+        {
+            // Arrange
+            const string Tml = "a=\"\\\"\""; // a = "\""
+
+            // Act
+            var table = Toml.ReadString(Tml);
+
+            // Assert
+            ((TomlValue<string>)table["a"]).Value.Should().Be("\"");
+        }
+
         public class TestTable
         {
             public string label { get; set; }

--- a/Test/Nett.Tests/WriteTomlTests.cs
+++ b/Test/Nett.Tests/WriteTomlTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using Nett.Tests.Util;
 using Xunit;
 
 namespace Nett.Tests
@@ -116,7 +117,7 @@ V = 666
             var s = Toml.WriteString(tc, cfg);
 
             // Assert
-            Assert.Equal(exp.Trim(), s.Trim());
+            s.ShouldBeNormalizedEqualTo(exp);
         }
 
         [Fact]
@@ -124,10 +125,11 @@ V = 666
         {
             var s = Toml.WriteString(new WithBoolProperty());
 
-            s.Should().Be(
-                @"TheInt = 0
+            var exp = @"TheInt = 0
 TheBool = false
-");
+";
+
+            s.ShouldBeNormalizedEqualTo(exp);
         }
 
         [Fact]
@@ -156,7 +158,7 @@ TheBool = false
         public void Write_WhenClrObjectIsDictionary_WritesCorrectToml()
         {
             // Arrange
-            Dictionary<string, object> d = new Dictionary<string, object>()
+            var d = new Dictionary<string, object>()
             {
                 { "i", 1 },
                 { "s", "s" },
@@ -171,7 +173,7 @@ TheBool = false
             var s = Toml.WriteString(d);
 
             // Assert
-            s.Trim().Should().Be(@"
+            s.Trim().ShouldBeNormalizedEqualTo(@"
 i = 1
 s = ""s""
 


### PR DESCRIPTION
A escaped quote at the start of a string fails to be parsed.