### PR TITLE
Support TomlTableArray and jagged TomlArray in Nett.AspNet

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,7 @@ Nett:
 + Fix: Improve conversion error messages [#29](https://github.com/paiden/Nett/issues/29)
 
 AspNet:
++ Add: Support for array of tables and jagged arrays conversion [#75](https://github.com/paiden/Nett/issues/75)
 + Fix: Fix missing dependency for NuGet package [#72](https://github.com/paiden/Nett/issues/72)
 
 Exp:

--- a/Source/Nett.AspNet/ProviderDictionaryConverter.cs
+++ b/Source/Nett.AspNet/ProviderDictionaryConverter.cs
@@ -19,6 +19,7 @@ namespace Nett.AspNet
             {
                 switch (r.Value)
                 {
+                    case TomlTableArray ta: ProcessTableArray(dict, ta, FullKey(r)); break;
                     case TomlTable t: ProcessTable(dict, t, keyPrefix + r.Key + ":"); break;
                     case TomlArray a: ProcessArray(dict, a, FullKey(r)); break;
                     case TomlBool b: AddEntry(r, b.Value.ToString(CultureInfo.InvariantCulture)); break;
@@ -41,6 +42,15 @@ namespace Nett.AspNet
 
             string FullKey(KeyValuePair<string, TomlObject> row)
                 => keyPrefix + row.Key;
+        }
+
+        private static void ProcessTableArray(Dictionary<string, string> dict, TomlTableArray tableArray, string keyPrefix)
+        {
+            for (int i = 0; i < tableArray.Items.Count; i++)
+            {
+                TomlTable table = tableArray.Items[i];
+                ProcessTable(dict, table, $"{keyPrefix}:{i}:");
+            }
         }
 
         private static void ProcessArray(Dictionary<string, string> dict, TomlArray array, string fullKey)

--- a/Source/Nett.AspNet/ProviderDictionaryConverter.cs
+++ b/Source/Nett.AspNet/ProviderDictionaryConverter.cs
@@ -59,12 +59,12 @@ namespace Nett.AspNet
             {
                 if (array.Items[i] is TomlArray a)
                 {
-                    throw new InvalidOperationException(
-                        $"AspNet provider cannot handle jagged arrays, only simple arrays are supported." +
-                        $"The arrays key is '{fullKey}'.");
+                    ProcessArray(dict, a, $"{fullKey}:{i}");
                 }
-
-                dict[$"{fullKey}:{i}"] = array.Items[i].ToString();
+                else
+                {
+                    dict[$"{fullKey}:{i}"] = array.Items[i].ToString();
+                }
             }
         }
     }

--- a/Test/Nett.AspNet.Tests/ProviderDictionaryConverterTests.cs
+++ b/Test/Nett.AspNet.Tests/ProviderDictionaryConverterTests.cs
@@ -39,18 +39,47 @@ SSOPT2 = 16.4");
         }
 
         [Fact]
-        public void ToProviderDictionary_WhenTomlContainsTblArray_ProducesUsefulErrorMessage()
+        public void ToProviderDictionary_Converts_TomlTableArray()
         {
             // Arrange
             var tml = Toml.ReadString(@"
-[[x]]
-[[x]]");
+[[tableArray]]
+
+[[tableArray]]
+STA1 = ""array1""
+STA2 = 1
+
+[[tableArray]]
+
+[[tableArray]]
+STA1 = ""array3""
+STA2 = 3
+
+[[tableArray.nestedTableArray]]
+NTA1 = ""nestedArray0""
+NTA2 = 10
+
+[[tableArray.nestedTableArray]]
+
+[[tableArray.nestedTableArray]]
+NTA1 = ""nestedArray2""
+NTA2 = 22");
 
             // Act
-            Action a = () => ProviderDictionaryConverter.ToProviderDictionary(tml);
+            var providerDict = ProviderDictionaryConverter.ToProviderDictionary(tml);
 
             // Assert
-            a.ShouldThrow<InvalidOperationException>().WithMessage("AspNet provider cannot handle TOML object of type 'array of tables'. The objects key is 'x'.");
+            providerDict.Should().Equal(new Dictionary<string, string>()
+            {
+                { "tableArray:1:STA1", "array1" },
+                { "tableArray:1:STA2", "1" },
+                { "tableArray:3:STA1", "array3" },
+                { "tableArray:3:STA2", "3" },
+                { "tableArray:3:nestedTableArray:0:NTA1", "nestedArray0" },
+                { "tableArray:3:nestedTableArray:0:NTA2", "10" },
+                { "tableArray:3:nestedTableArray:2:NTA1", "nestedArray2" },
+                { "tableArray:3:nestedTableArray:2:NTA2", "22" },
+            });
         }
 
         [Fact]

--- a/Test/Nett.AspNet.Tests/ProviderDictionaryConverterTests.cs
+++ b/Test/Nett.AspNet.Tests/ProviderDictionaryConverterTests.cs
@@ -83,17 +83,24 @@ NTA2 = 22");
         }
 
         [Fact]
-        public void ToProviderDictionary_WhenTomlContainsJaggedArray_ProducesUsefulErrorMessage()
+        public void ToProviderDictionary_Converts_JaggedArray()
         {
             // Arrange
             var tml = Toml.ReadString(@"
-x = [[1]]");
+jaggedArray = [ [ ""index00"", ""index01"" ], [ ""index10"" ], [], [ ""index30"" ] ]
+");
 
             // Act
-            Action a = () => ProviderDictionaryConverter.ToProviderDictionary(tml);
+            var providerDict = ProviderDictionaryConverter.ToProviderDictionary(tml);
 
             // Assert
-            a.ShouldThrow<InvalidOperationException>().WithMessage("AspNet provider cannot handle jagged arrays, only simple arrays are supported.The arrays key is 'x'.");
+            providerDict.Should().Equal(new Dictionary<string, string>()
+            {
+                { "jaggedArray:0:0", "index00" },
+                { "jaggedArray:0:1", "index01" },
+                { "jaggedArray:1:0", "index10" },
+                { "jaggedArray:3:0", "index30" }
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes #75.

I've based the implementation on matching the output of [Microsoft.Extensions.Configuration.Json](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Json).

A thing to note is that empty objects/arrays are still counted but of course not added to the final output.
This means that the JSON library produces:
```csharp
{ "tableArray:0:id", "1" },
{ "tableArray:2:id", "2" }
```
when passed:
```json
{
  "tableArray": [
    {
      "id": 1
    },
    {
    },
    {
      "id": 2
    }
  ]
}
```

I couldn't find whether that is a bug or not but I assume it isn't since the object is there, it just doesn't have any values.
The [Binder](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Binder) doesn't seem to care either way.

So going by that assumption, the following TOML produces the above data as well:
```toml
[[tableArray]]
id = 1

[[tableArray]]

[[tableArray]]
id = 2
```