### PR TITLE
Option to treat provider dictionary keys as case-insensitive in Nett.AspNet

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,9 @@
 Nett:
 + Add: Callback for processing non map-able table rows [#78](https://github.com/paiden/Nett/issues/78)
 
+AspNet:
++ Add: Option to treat provider dictionary config keys as case insensitive [#81](https://github.com/paiden/Nett/issues/81)
+
 ## v0.12.0
 Nett:
 + Fix: ArgumentOutOfRange exception when DateTime field/prop not initialized [#25](https://github.com/paiden/Nett/issues/25)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,9 +1,10 @@
+## v0.14.0
+AspNet:
++ Add: Option to treat provider dictionary config keys as case insensitive [#81](https://github.com/paiden/Nett/issues/81)
+
 ## v0.13.0
 Nett:
 + Add: Callback for processing non map-able table rows [#78](https://github.com/paiden/Nett/issues/78)
-
-AspNet:
-+ Add: Option to treat provider dictionary config keys as case insensitive [#81](https://github.com/paiden/Nett/issues/81)
 
 ## v0.12.0
 Nett:

--- a/Source/Nett.AspNet/ProviderDictionaryConverter.cs
+++ b/Source/Nett.AspNet/ProviderDictionaryConverter.cs
@@ -7,8 +7,11 @@ namespace Nett.AspNet
     internal static class ProviderDictionaryConverter
     {
         public static Dictionary<string, string> ToProviderDictionary(TomlTable table)
+            => ToProviderDictionary(table, null);
+
+        public static Dictionary<string, string> ToProviderDictionary(TomlTable table, StringComparer keyComparer)
         {
-            Dictionary<string, string> dict = new Dictionary<string, string>();
+            Dictionary<string, string> dict = new Dictionary<string, string>(comparer: keyComparer);
             ProcessTable(dict, table, keyPrefix: string.Empty);
             return dict;
         }

--- a/Source/Nett.AspNet/TomlConfigurationProvider.cs
+++ b/Source/Nett.AspNet/TomlConfigurationProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.Extensions.Configuration;
 using Nett.Extensions;
 
@@ -6,16 +7,28 @@ namespace Nett.AspNet
 {
     public sealed class TomlConfigurationProvider : FileConfigurationProvider
     {
+        public bool CaseInsensitiveKeys { get; }
+
         public TomlConfigurationProvider(TomlConfigurationSource source)
             : base(source)
         {
             source.CheckNotNull(nameof(source));
+
+            this.CaseInsensitiveKeys = source.CaseInsensitiveKeys;
         }
 
         public override void Load(Stream stream)
         {
             var table = Toml.ReadStream(stream);
-            this.Data = ProviderDictionaryConverter.ToProviderDictionary(table);
+
+            if (this.CaseInsensitiveKeys)
+            {
+                this.Data = ProviderDictionaryConverter.ToProviderDictionary(table, StringComparer.OrdinalIgnoreCase);
+            }
+            else
+            {
+                this.Data = ProviderDictionaryConverter.ToProviderDictionary(table);
+            }
         }
     }
 }

--- a/Source/Nett.AspNet/TomlConfigurationSource.cs
+++ b/Source/Nett.AspNet/TomlConfigurationSource.cs
@@ -4,6 +4,8 @@ namespace Nett.AspNet
 {
     public class TomlConfigurationSource : FileConfigurationSource
     {
+        public bool CaseInsensitiveKeys { get; set; }
+
         public override IConfigurationProvider Build(IConfigurationBuilder builder)
         {
             return new TomlConfigurationProvider(this);

--- a/Test/Nett.AspNet.Tests/ProviderDictionaryConverterTests.cs
+++ b/Test/Nett.AspNet.Tests/ProviderDictionaryConverterTests.cs
@@ -102,5 +102,62 @@ jaggedArray = [ [ ""index00"", ""index01"" ], [ ""index10"" ], [], [ ""index30""
                 { "jaggedArray:3:0", "index30" }
             });
         }
+
+        [Fact]
+        public void ToProviderDictionary_Converts_With_Case_Sensitive_Keys_By_Default()
+        {
+            // Arrange
+            var tml = Toml.ReadString(@"
+Option1 = 1
+Option2 = ""opt1""
+
+[SubOption]
+SubOption1 = ""suboption1""
+");
+
+            // Act
+            var providerDict = ProviderDictionaryConverter.ToProviderDictionary(tml);
+
+            // Assert
+            providerDict.Should().ContainKeys("Option1", "Option2", "SubOption:SubOption1");
+            providerDict.Should().NotContainKeys("option1", "option2", "subOption:subOption1");
+        }
+
+        [Fact]
+        public void ToProviderDictionary_Converts_To_Dictionary_With_Key_Comparer_When_Specified()
+        {
+            // Arrange
+            var tml = Toml.ReadString(@"
+Option1 = 1
+Option2 = ""opt1""
+
+[SubOption]
+SubOption1 = ""suboption1""
+suboption1 = ""otheropt""
+");
+
+            // Act
+            var providerDict = ProviderDictionaryConverter.ToProviderDictionary(tml, StringComparer.OrdinalIgnoreCase);
+
+            // Assert
+            providerDict.Should().ContainKeys("Option1", "Option2", "SubOption:SubOption1");
+            providerDict.Should().ContainKeys("option1", "option2", "suboption:suboption1");
+        }
+
+        [Fact]
+        public void ToProviderDictionary_With_Case_Insensitive_Key_Comparer_Overrides_Earlier_Keys()
+        {
+            // Arrange
+            var tml = Toml.ReadString(@"
+Option = 1
+option = ""opt1""
+");
+
+            // Act
+            var providerDict = ProviderDictionaryConverter.ToProviderDictionary(tml, StringComparer.OrdinalIgnoreCase);
+
+            // Assert
+            providerDict["option"].Should().Be("opt1", "the provider dictionary overrides earlier values with the last one found for a key.");
+        }
     }
 }


### PR DESCRIPTION
Added a way to configure TomlConfigurationProvider to load a case insensitive data dictionary.

Implements issue #81 by adding an overload to ProviderDictionaryConverter.ToProviderDictionary that accepts a StringComparer for the created dictionary.

TomlConfigurationProvider now calls this overload with a StringComparer.OrdinalIgnore case value if the added CaseInsensitiveKeys property is set to true.

The CaseInsensitiveKeys property on the provider can be set by modifying the identically named property on TomlConfigurationSource.

In turn, CaseInsensitiveKeys on the source can be set by calling an AddTomlFile overload that has a configureSource parameter.

Also replaced the provider and path checks in the main AddTomlFile method with a call to ResolveFileProvider which does the same thing.

**Example usage**
```csharp
var builder = new ConfigurationBuilder()
    .AddTomlFile("config.toml", s => s.CaseInsensitiveKeys = true);
```